### PR TITLE
Fix styling for input

### DIFF
--- a/frontend/src/components/Home/Home.css
+++ b/frontend/src/components/Home/Home.css
@@ -7,6 +7,7 @@
   height: 100vh;
 }
 
-.ant-input {
+.ant-input-lg {
   background-color: #FFFFFF;
+  border-radius: 10px;
 }

--- a/frontend/src/components/Login/Login.css
+++ b/frontend/src/components/Login/Login.css
@@ -33,6 +33,7 @@
   border: none;
   outline: none;
   border-radius: 4px;
+  font-family: "Asap", sans-serif;
 }
 
 .login__button--login {


### PR DESCRIPTION
## Description
This PR fixes the input background color for login. A different class name (`.ant-input-lg`) is used instead to create a white background for the input in `Home`.

<img width="467" alt="Screen Shot 2019-10-18 at 1 36 43 PM" src="https://user-images.githubusercontent.com/21976658/67126654-75879700-f1ac-11e9-8435-2d33f3d6751c.png">
