### PR TITLE
Fix likes and dislikes bug when sorting

### DIFF
--- a/frontend/src/components/Home/Feed/Post/Post.js
+++ b/frontend/src/components/Home/Feed/Post/Post.js
@@ -7,20 +7,8 @@ const moment = require('moment');
 
 class Post extends Component {
   state = {
-    numLikes: 0,
-    numDislikes: 0,
-    hasLiked: false,
-    hasDisliked: false
-  }
-
-  componentDidMount = () => {
-    console.log(this.props);
-    this.setState({
-      numLikes: this.props.likes,
-      numDislikes: this.props.dislikes,
-      hasLiked: this.props.hasLiked,
-      hasDisliked: this.props.hasDisliked
-    });
+    likes: this.props.likes,
+    dislikes: this.props.dislikes,
   }
 
   handlePostLike = (e, postId, hasLiked) => {
@@ -46,10 +34,6 @@ class Post extends Component {
       .then(data => {
         console.log("Response after LIKING post", data);
         this.props.addLikedId(postId);
-        this.setState(prevState => ({
-          numLikes: prevState.numLikes + 1,
-          hasLiked: true
-        }));
       })
       .catch(error => {
         console.error(error);
@@ -82,10 +66,6 @@ class Post extends Component {
       .then(data => {
         console.log("Response after DISLIKING post", data);
         this.props.addDislikedId(postId);
-        this.setState(prevState => ({
-          numDislikes: prevState.numDislikes + 1,
-          hasDisliked: true
-        }));
       })
       .catch(error => {
         console.error(error);
@@ -95,7 +75,8 @@ class Post extends Component {
 
   render() {
     const { name, date, content, images, tags, posting_id: postId } = this.props;
-    const { hasLiked, hasDisliked } = this.state;
+    
+    console.log("Received props in post", this.props)
 
     return (  
       <div className="post__container">
@@ -118,26 +99,26 @@ class Post extends Component {
         <div className="post__tags">
           {tags.length > 0 && tags.map(tag => <Tag color="red">{tag}</Tag> )}
         </div>
-        <div className="post__reactions">
+        {<div className="post__reactions">
           <Tooltip title="Like">
             <Icon
               className="post__react"
               type="like"
-              theme={hasLiked ? "filled" : "outlined"}
-              onClick={e => this.handlePostLike(e, postId, hasLiked)}
+              theme={this.props.hasLiked ? "filled" : "outlined"}
+              onClick={e => this.handlePostLike(e, postId, this.props.hasLiked)}
             />
           </Tooltip>
-          <span className="post__react--count">{this.state.numLikes}</span>
+          <span className="post__react--count">{this.props.likes}</span>
           <Tooltip title="Dislike">
             <Icon
               className="post__react"
               type="dislike"
-              theme={hasDisliked ? "filled" : "outlined"}
-              onClick={e => this.handlePostDislike(e, postId, hasDisliked)}
+              theme={this.props.hasDisliked ? "filled" : "outlined"}
+              onClick={e => this.handlePostDislike(e, postId, this.props.hasDisliked)}
             />
           </Tooltip>
-          <span className="post__react--count">{this.state.numDislikes}</span>
-        </div>
+          <span className="post__react--count">{this.props.dislikes}</span>
+        </div>}
       </div>
     )
   }

--- a/frontend/src/components/Home/Feed/Post/Post.js
+++ b/frontend/src/components/Home/Feed/Post/Post.js
@@ -6,11 +6,6 @@ import { BASE_URL, showErrorMessage, REACTION_ERROR } from '../../../../constant
 const moment = require('moment');
 
 class Post extends Component {
-  state = {
-    likes: this.props.likes,
-    dislikes: this.props.dislikes,
-  }
-
   handlePostLike = (e, postId, hasLiked) => {
     e.preventDefault();
 
@@ -74,10 +69,19 @@ class Post extends Component {
   }
 
   render() {
-    const { name, date, content, images, tags, posting_id: postId } = this.props;
+    const {
+      name,
+      date,
+      content,
+      images,
+      tags,
+      hasLiked,
+      hasDisliked,
+      likes,
+      dislikes,
+      posting_id: postId
+    } = this.props;
     
-    console.log("Received props in post", this.props)
-
     return (  
       <div className="post__container">
         <div className="post__name">{name}</div>
@@ -104,20 +108,20 @@ class Post extends Component {
             <Icon
               className="post__react"
               type="like"
-              theme={this.props.hasLiked ? "filled" : "outlined"}
-              onClick={e => this.handlePostLike(e, postId, this.props.hasLiked)}
+              theme={hasLiked ? "filled" : "outlined"}
+              onClick={e => this.handlePostLike(e, postId, hasLiked)}
             />
           </Tooltip>
-          <span className="post__react--count">{this.props.likes}</span>
+          <span className="post__react--count">{likes}</span>
           <Tooltip title="Dislike">
             <Icon
               className="post__react"
               type="dislike"
-              theme={this.props.hasDisliked ? "filled" : "outlined"}
-              onClick={e => this.handlePostDislike(e, postId, this.props.hasDisliked)}
+              theme={hasDisliked ? "filled" : "outlined"}
+              onClick={e => this.handlePostDislike(e, postId, hasDisliked)}
             />
           </Tooltip>
-          <span className="post__react--count">{this.props.dislikes}</span>
+          <span className="post__react--count">{dislikes}</span>
         </div>}
       </div>
     )

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,6 +1,6 @@
 import { message } from 'antd';
 
-export const BASE_URL = "http://2b5018cd.ngrok.io";
+export const BASE_URL = "http://6b3ba881.ngrok.io";
 export const inputIconColor = { color: 'rgba(0, 0, 0)' };
 export const PASSWORD_MATCH_ERROR = "Your passwords don't match!";
 export const EMPTY_INPUT_ERROR = "You left an input field empty!";


### PR DESCRIPTION
## Description
When the user sorted the feed, there was a bug (dealing with mutating the `posts` array) that didn't render the likes and dislikes correctly. Now, instead of each `Post` component updating their respective local states, all the logic is done in `Feed`, so `Post` only relies on props.